### PR TITLE
feat(zenohsrc): ring / drop-oldest receive handler to bound live latency (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to gst-plugin-zenoh will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`zenohsrc` ring / drop-oldest receive handler** for live sources (#13). New
+  `handler` property (`fifo` default, lossless/unbounded — or `ring`, keep the
+  most-recent `queue-depth` samples and drop the oldest) plus `queue-depth`
+  (1-100000, default 30) and a read-only `dropped` stat counting evictions. The
+  `ring` handler bounds latency build-up for live RTP/MPEG-TS where staleness is
+  worse than loss; the built-in Zenoh ring drops silently, so a small
+  drop-counting handler backs the stat. FIFO remains the default — behavior is
+  unchanged unless `handler=ring` is selected.
+
 ## [0.5.0] - 2026-06-29
 
 The **0.5.0 correctness milestone**: four P0 bug-fix epics plus CI quality gates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ src/
   - `change_state(ReadyToNull)`: Tears down all Zenoh resources
   - The `render()` method maps GStreamer buffers and publishes via `publisher.put().wait()`
 
-- **ZenohSrc** (`zenohsrc/imp.rs`): Extends `gst_base::PushSrc`. On `start()`, creates a Zenoh session and subscriber with FIFO handler. The `create()` method uses `subscriber.recv_timeout()` (configurable via `receive-timeout-ms`) to get samples. Supports buffer metadata restoration via `apply-buffer-meta` property.
+- **ZenohSrc** (`zenohsrc/imp.rs`): Extends `gst_base::PushSrc`. On `start()`, creates a Zenoh session and subscriber with either the default FIFO handler or a drop-oldest ring handler (`handler`/`queue-depth`). The `create()` method uses `subscriber.recv_timeout()` (configurable via `receive-timeout-ms`) to get samples. Supports buffer metadata restoration via `apply-buffer-meta` property.
 
 - **ZenohDemux** (`zenohdemux/imp.rs`): Extends `gst::Element`. Creates dynamic source pads based on incoming key expressions. Uses a receiver thread for Zenoh subscription. Supports three pad naming strategies: `full-path`, `last-segment`, and `hash`. Attaches key expression as buffer metadata.
 
@@ -230,12 +230,14 @@ ZenohSink additional (publisher-side QoS — these are NOT on the subscriber ele
 ZenohSrc additional:
 - `receive-timeout-ms` (int): Timeout for receiving samples in ms, 10-5000 (default: 100)
 - `apply-buffer-meta` (bool): Apply buffer timing from Zenoh attachments
+- `handler`: `fifo` (lossless, unbounded, default) or `ring` (keep most-recent `queue-depth`, drop oldest) — use `ring` for live sources to bound latency
+- `queue-depth` (int): Ring-handler capacity, 1-100000 (default: 30); ignored for `fifo`
 
 ZenohDemux additional:
 - `pad-naming`: `full-path`, `last-segment`, or `hash`
 - `apply-buffer-meta` (bool): Apply buffer timing from Zenoh attachments
 
-Statistics (read-only): `bytes-sent`/`bytes-received`, `messages-sent`/`messages-received`, `errors`, `pads-created` (demux only)
+Statistics (read-only): `bytes-sent`/`bytes-received`, `messages-sent`/`messages-received`, `errors`, `dropped` (src ring handler only), `pads-created` (demux only)
 
 ## Dependencies
 

--- a/src/zenohsrc/imp.rs
+++ b/src/zenohsrc/imp.rs
@@ -1,6 +1,11 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock, Mutex, Weak};
 use std::time::Duration;
+
+use zenoh::handlers::{Callback, FifoChannelHandler, IntoHandler};
+use zenoh::pubsub::Subscriber;
+use zenoh::sample::Sample;
 
 use gst::subclass::prelude::URIHandlerImpl;
 use gst::{glib, prelude::*, subclass::prelude::*};
@@ -30,16 +35,182 @@ struct Statistics {
     errors: u64,
 }
 
+/// Receive-handler strategy for the Zenoh subscriber.
+///
+/// `Fifo` (default) is the lossless, unbounded handler — every sample is queued
+/// in order. `Ring` keeps only the most recent `queue-depth` samples, dropping
+/// the oldest when full; this bounds latency build-up for live sources (e.g. RTP
+/// video) where staleness is worse than loss.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum HandlerMode {
+    #[default]
+    Fifo,
+    Ring,
+}
+
+impl HandlerMode {
+    /// Parse the property nick (`"fifo"` / `"ring"`); `None` if unrecognized.
+    fn from_nick(s: &str) -> Option<Self> {
+        match s {
+            "fifo" => Some(Self::Fifo),
+            "ring" => Some(Self::Ring),
+            _ => None,
+        }
+    }
+
+    fn as_nick(self) -> &'static str {
+        match self {
+            Self::Fifo => "fifo",
+            Self::Ring => "ring",
+        }
+    }
+}
+
+/// Generic bounded "keep latest N" buffer that drops — and counts — the oldest
+/// element when full.
+///
+/// Extracted from the handler so the drop-oldest accounting is unit-tested
+/// directly: the handler is `Sample`-typed and `Sample` has no public
+/// constructor, so the logic is exercised here with a testable element type.
+/// Mirrors Zenoh's own `RingChannel`, but the built-in ring drops silently
+/// whereas this one records every eviction for the `dropped` stat.
+struct CountingRing<T> {
+    ring: Mutex<VecDeque<T>>,
+    capacity: usize,
+    dropped: Arc<AtomicU64>,
+}
+
+impl<T> CountingRing<T> {
+    fn new(capacity: usize, dropped: Arc<AtomicU64>) -> Self {
+        Self {
+            ring: Mutex::new(VecDeque::with_capacity(capacity)),
+            capacity,
+            dropped,
+        }
+    }
+
+    /// Push the newest element, evicting (and counting) the oldest when full.
+    fn push(&self, item: T) {
+        let mut ring = self.ring.lock().unwrap_or_else(|e| e.into_inner());
+        if ring.len() >= self.capacity {
+            ring.pop_front();
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+        ring.push_back(item);
+    }
+
+    /// Pop the oldest retained element, if any.
+    fn pop(&self) -> Option<T> {
+        self.ring
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .pop_front()
+    }
+}
+
+/// Shared inner state of the drop-oldest ring channel: the counting ring plus a
+/// `flume(1)` "not empty" signal so the receiver can block with a timeout and
+/// observe disconnection (all senders dropped).
+struct CountingRingInner {
+    ring: CountingRing<Sample>,
+    not_empty: flume::Receiver<()>,
+}
+
+/// Keep-latest-N, drop-oldest subscriber handler factory with eviction counting.
+struct CountingRingChannel {
+    capacity: usize,
+    dropped: Arc<AtomicU64>,
+}
+
+/// Receiver half of [`CountingRingChannel`], stored inside the `Subscriber`.
+struct CountingRingHandler {
+    inner: Weak<CountingRingInner>,
+}
+
+impl CountingRingHandler {
+    /// Receive the next sample, waiting up to `timeout`.
+    ///
+    /// `Ok(Some(_))` when a sample is available, `Ok(None)` on timeout, `Err(_)`
+    /// once disconnected (subscriber/callback dropped). The `ZResult<Option<_>>`
+    /// shape matches Zenoh's FIFO/ring handlers so the same receive loop drives
+    /// either handler.
+    fn recv_timeout(&self, timeout: Duration) -> zenoh::Result<Option<Sample>> {
+        let Some(inner) = self.inner.upgrade() else {
+            return Err("ring channel has been closed".into());
+        };
+        loop {
+            if let Some(sample) = inner.ring.pop() {
+                return Ok(Some(sample));
+            }
+            match inner.not_empty.recv_timeout(timeout) {
+                Ok(()) => {}
+                Err(flume::RecvTimeoutError::Timeout) => return Ok(None),
+                Err(flume::RecvTimeoutError::Disconnected) => {
+                    // Drain once more: a sample may have landed between the pull
+                    // above and the senders being dropped.
+                    if let Some(sample) = inner.ring.pop() {
+                        return Ok(Some(sample));
+                    }
+                    return Err("ring channel disconnected".into());
+                }
+            }
+        }
+    }
+}
+
+impl IntoHandler<Sample> for CountingRingChannel {
+    type Handler = CountingRingHandler;
+
+    fn into_handler(self) -> (Callback<Sample>, Self::Handler) {
+        let (sender, receiver) = flume::bounded::<()>(1);
+        let inner = Arc::new(CountingRingInner {
+            ring: CountingRing::new(self.capacity, self.dropped),
+            not_empty: receiver,
+        });
+        let handler = CountingRingHandler {
+            inner: Arc::downgrade(&inner),
+        };
+        // The callback owns the only strong reference to `inner`, so dropping the
+        // subscriber drops the callback, releases `inner` and the `flume` sender,
+        // and makes the handler's `recv_timeout` observe disconnection.
+        let callback = Callback::from(move |sample: Sample| {
+            inner.ring.push(sample);
+            // Wake a blocked receiver; capacity-1, so a full channel already
+            // carries a pending wake-up.
+            let _ = sender.try_send(());
+        });
+        (callback, handler)
+    }
+}
+
+/// A subscriber with either the default FIFO handler or the drop-oldest ring
+/// handler, unified behind a single `recv_timeout` so `create()` is handler-agnostic.
+enum SubscriberHandle {
+    Fifo(Subscriber<FifoChannelHandler<Sample>>),
+    Ring(Subscriber<CountingRingHandler>),
+}
+
+impl SubscriberHandle {
+    fn recv_timeout(&self, timeout: Duration) -> zenoh::Result<Option<Sample>> {
+        match self {
+            SubscriberHandle::Fifo(s) => s.recv_timeout(timeout),
+            SubscriberHandle::Ring(s) => s.recv_timeout(timeout),
+        }
+    }
+}
+
 struct Started {
     // Keeping session field to maintain ownership and prevent session from being dropped
     // while subscriber is still in use. This can be either owned or shared.
     _session: SessionWrapper,
     /// Subscriber wrapped in `Arc` so `create()` can clone it out and release the
     /// `state` lock before the blocking `recv_timeout` poll loop.
-    subscriber:
-        Arc<zenoh::pubsub::Subscriber<zenoh::handlers::FifoChannelHandler<zenoh::sample::Sample>>>,
+    subscriber: Arc<SubscriberHandle>,
     /// Statistics tracking (shared for thread-safe updates)
     stats: Arc<Mutex<Statistics>>,
+    /// Samples dropped by the ring handler (stays 0 for FIFO). Updated from the
+    /// Zenoh callback thread, read by the `dropped` property — hence an atomic.
+    dropped: Arc<AtomicU64>,
 }
 
 /// Wrapper to handle both owned and shared Zenoh sessions.
@@ -126,6 +297,11 @@ struct Settings {
     receive_timeout_ms: u64,
     /// Apply buffer timing metadata (PTS, DTS, duration, flags) from received messages (default: true)
     apply_buffer_meta: bool,
+    /// Subscriber receive-handler strategy (FIFO vs. drop-oldest ring).
+    handler: HandlerMode,
+    /// Ring-handler capacity: max samples retained before the oldest is dropped.
+    /// Ignored for the (unbounded) FIFO handler.
+    queue_depth: u32,
     /// Optional external Zenoh session to share with other elements (Rust API)
     external_session: Option<zenoh::Session>,
     /// Session group name for sharing sessions via property (gst-launch compatible)
@@ -139,6 +315,8 @@ impl Default for Settings {
             config_file: None,
             receive_timeout_ms: 100, // 100ms default for good responsiveness
             apply_buffer_meta: true, // Default to applying buffer timing metadata
+            handler: HandlerMode::Fifo, // Lossless default preserves prior behavior
+            queue_depth: 30,         // ~1s at 30fps; only used by the ring handler
             external_session: None,
             session_group: None,
         }
@@ -251,6 +429,22 @@ impl ObjectImpl for ZenohSrc {
                     .default_value(true)
                     .build(),
 
+                // Receive-handler strategy
+                glib::ParamSpecString::builder("handler")
+                    .nick("Receive Handler")
+                    .blurb("Subscriber receive handler: 'fifo' (lossless, unbounded, default) or 'ring' (keep only the most recent 'queue-depth' samples, dropping the oldest). Use 'ring' for live sources to bound latency build-up.")
+                    .default_value(Some("fifo"))
+                    .build(),
+
+                // Ring-handler depth
+                glib::ParamSpecUInt::builder("queue-depth")
+                    .nick("Queue Depth")
+                    .blurb("Maximum samples retained by the 'ring' handler before the oldest is dropped. Ignored for the 'fifo' handler.")
+                    .default_value(30)
+                    .minimum(1)
+                    .maximum(100_000)
+                    .build(),
+
                 // Session sharing property
                 glib::ParamSpecString::builder("session-group")
                     .nick("Session Group")
@@ -273,6 +467,11 @@ impl ObjectImpl for ZenohSrc {
                     .blurb("Total number of errors encountered")
                     .read_only()
                     .build(),
+                glib::ParamSpecUInt64::builder("dropped")
+                    .nick("Dropped")
+                    .blurb("Total samples dropped by the 'ring' handler since the element started (always 0 for the 'fifo' handler)")
+                    .read_only()
+                    .build(),
             ]
         });
 
@@ -282,7 +481,12 @@ impl ObjectImpl for ZenohSrc {
     fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
         // Check if we're in a state where property changes are allowed
         let state = self.state.lock().unwrap();
-        if state.is_started() && matches!(pspec.name(), "key-expr" | "config" | "session-group") {
+        if state.is_started()
+            && matches!(
+                pspec.name(),
+                "key-expr" | "config" | "session-group" | "handler" | "queue-depth"
+            )
+        {
             gst::warning!(
                 CAT,
                 "Cannot change property '{}' while element is started",
@@ -319,6 +523,21 @@ impl ObjectImpl for ZenohSrc {
             "apply-buffer-meta" => {
                 settings.apply_buffer_meta = value.get::<bool>().expect("type checked upstream");
             }
+            "handler" => {
+                let nick = value.get::<String>().expect("type checked upstream");
+                match HandlerMode::from_nick(&nick) {
+                    Some(mode) => settings.handler = mode,
+                    None => gst::warning!(
+                        CAT,
+                        "Invalid handler '{}' (expected 'fifo' or 'ring'); keeping '{}'",
+                        nick,
+                        settings.handler.as_nick()
+                    ),
+                }
+            }
+            "queue-depth" => {
+                settings.queue_depth = value.get::<u32>().expect("type checked upstream");
+            }
             "session-group" => {
                 settings.session_group = value
                     .get::<Option<String>>()
@@ -333,14 +552,16 @@ impl ObjectImpl for ZenohSrc {
     fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
         match pspec.name() {
             // Configuration properties - read from settings
-            "key-expr" | "config" | "receive-timeout-ms" | "apply-buffer-meta"
-            | "session-group" => {
+            "key-expr" | "config" | "receive-timeout-ms" | "apply-buffer-meta" | "handler"
+            | "queue-depth" | "session-group" => {
                 let settings = self.settings.lock().unwrap();
                 match pspec.name() {
                     "key-expr" => settings.key_expr.to_value(),
                     "config" => settings.config_file.to_value(),
                     "receive-timeout-ms" => settings.receive_timeout_ms.to_value(),
                     "apply-buffer-meta" => settings.apply_buffer_meta.to_value(),
+                    "handler" => settings.handler.as_nick().to_value(),
+                    "queue-depth" => settings.queue_depth.to_value(),
                     "session-group" => settings.session_group.to_value(),
                     _ => unreachable!(),
                 }
@@ -366,6 +587,14 @@ impl ObjectImpl for ZenohSrc {
                 let state = self.state.lock().unwrap();
                 if let State::Started(ref started) = *state {
                     started.stats.lock().unwrap().errors.to_value()
+                } else {
+                    0u64.to_value()
+                }
+            }
+            "dropped" => {
+                let state = self.state.lock().unwrap();
+                if let State::Started(ref started) = *state {
+                    started.dropped.load(Ordering::Relaxed).to_value()
                 } else {
                     0u64.to_value()
                 }
@@ -431,6 +660,8 @@ impl BaseSrcImpl for ZenohSrc {
         let config_file = settings.config_file.clone();
         let external_session = settings.external_session.clone();
         let session_group = settings.session_group.clone();
+        let handler = settings.handler;
+        let queue_depth = settings.queue_depth.max(1) as usize;
         drop(settings);
 
         // Validate the key expression
@@ -492,12 +723,38 @@ impl BaseSrcImpl for ZenohSrc {
         // publisher they're receiving from. This ensures consistent delivery guarantees
         // across the pub-sub connection without requiring manual coordination.
 
-        // Create subscriber
-        let subscriber = session_wrapper
-            .as_session()
-            .declare_subscriber(key_expr)
-            .wait()
-            .map_err(|e| ZenohError::Init(e).to_error_message())?;
+        // Create the subscriber with the configured receive handler. FIFO is the
+        // lossless default; ring keeps only the most recent `queue_depth` samples
+        // (drop-oldest) to bound latency for live sources, counting evictions.
+        let dropped = Arc::new(AtomicU64::new(0));
+        let subscriber = match handler {
+            HandlerMode::Fifo => {
+                gst::debug!(CAT, "Using FIFO receive handler (unbounded)");
+                let sub = session_wrapper
+                    .as_session()
+                    .declare_subscriber(key_expr)
+                    .wait()
+                    .map_err(|e| ZenohError::Init(e).to_error_message())?;
+                SubscriberHandle::Fifo(sub)
+            }
+            HandlerMode::Ring => {
+                gst::debug!(
+                    CAT,
+                    "Using ring receive handler (drop-oldest, depth={})",
+                    queue_depth
+                );
+                let sub = session_wrapper
+                    .as_session()
+                    .declare_subscriber(key_expr)
+                    .with(CountingRingChannel {
+                        capacity: queue_depth,
+                        dropped: dropped.clone(),
+                    })
+                    .wait()
+                    .map_err(|e| ZenohError::Init(e).to_error_message())?;
+                SubscriberHandle::Ring(sub)
+            }
+        };
         let subscriber = Arc::new(subscriber);
 
         // Clear any leftover flush signal from a previous run.
@@ -522,6 +779,7 @@ impl BaseSrcImpl for ZenohSrc {
             _session: session_wrapper,
             subscriber,
             stats: Arc::new(Mutex::new(Statistics::default())),
+            dropped,
         });
 
         gst::debug!(CAT, "ZenohSrc successfully transitioned to Started state");
@@ -981,6 +1239,12 @@ impl URIHandlerImpl for ZenohSrc {
         if !settings.apply_buffer_meta {
             params.push("apply-buffer-meta=false".to_string());
         }
+        if settings.handler != HandlerMode::Fifo {
+            params.push(format!("handler={}", settings.handler.as_nick()));
+        }
+        if settings.queue_depth != 30 {
+            params.push(format!("queue-depth={}", settings.queue_depth));
+        }
 
         if !params.is_empty() {
             uri.push('?');
@@ -1079,6 +1343,26 @@ impl URIHandlerImpl for ZenohSrc {
                                 }
                             };
                         }
+                        "handler" => {
+                            settings.handler = HandlerMode::from_nick(&value).ok_or_else(|| {
+                                glib::Error::new(
+                                    gst::URIError::BadUri,
+                                    &format!(
+                                        "Invalid handler value: {} (expected 'fifo' or 'ring')",
+                                        value
+                                    ),
+                                )
+                            })?;
+                        }
+                        "queue-depth" => {
+                            let depth: u32 = value.parse().map_err(|_| {
+                                glib::Error::new(
+                                    gst::URIError::BadUri,
+                                    &format!("Invalid queue-depth value: {}", value),
+                                )
+                            })?;
+                            settings.queue_depth = depth.clamp(1, 100_000);
+                        }
                         _ => {
                             gst::warning!(CAT, imp = self, "Unknown URI parameter: {}", key);
                         }
@@ -1088,5 +1372,53 @@ impl URIHandlerImpl for ZenohSrc {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handler_mode_nick_roundtrip() {
+        assert_eq!(HandlerMode::from_nick("fifo"), Some(HandlerMode::Fifo));
+        assert_eq!(HandlerMode::from_nick("ring"), Some(HandlerMode::Ring));
+        assert_eq!(HandlerMode::from_nick("bogus"), None);
+        assert_eq!(HandlerMode::Fifo.as_nick(), "fifo");
+        assert_eq!(HandlerMode::Ring.as_nick(), "ring");
+        // Default preserves prior (lossless) behavior.
+        assert_eq!(HandlerMode::default(), HandlerMode::Fifo);
+    }
+
+    #[test]
+    fn counting_ring_drops_oldest_and_counts() {
+        let dropped = Arc::new(AtomicU64::new(0));
+        let ring = CountingRing::new(2, dropped.clone());
+
+        // Push five into a depth-2 ring: the three oldest are evicted and counted.
+        for i in 0..5 {
+            ring.push(i);
+        }
+        assert_eq!(dropped.load(Ordering::Relaxed), 3);
+
+        // Only the two most recent survive, in arrival order (drop-oldest).
+        assert_eq!(ring.pop(), Some(3));
+        assert_eq!(ring.pop(), Some(4));
+        assert_eq!(ring.pop(), None);
+    }
+
+    #[test]
+    fn counting_ring_under_capacity_never_drops() {
+        let dropped = Arc::new(AtomicU64::new(0));
+        let ring = CountingRing::new(5, dropped.clone());
+
+        ring.push("a");
+        ring.push("b");
+        assert_eq!(dropped.load(Ordering::Relaxed), 0);
+
+        // FIFO order preserved when within capacity.
+        assert_eq!(ring.pop(), Some("a"));
+        assert_eq!(ring.pop(), Some("b"));
+        assert_eq!(ring.pop(), None);
     }
 }

--- a/src/zenohsrc/mod.rs
+++ b/src/zenohsrc/mod.rs
@@ -182,6 +182,23 @@ impl ZenohSrc {
         self.set_property("apply-buffer-meta", apply);
     }
 
+    /// Sets the subscriber receive-handler strategy.
+    ///
+    /// `"fifo"` (default) is lossless and unbounded; `"ring"` keeps only the most
+    /// recent [`queue_depth`](Self::set_queue_depth) samples, dropping the oldest
+    /// to bound latency on live sources. Must be set before the element starts.
+    pub fn set_handler(&self, handler: &str) {
+        self.set_property("handler", handler);
+    }
+
+    /// Sets the ring-handler depth (max samples retained before drop-oldest).
+    ///
+    /// Only affects the `"ring"` handler; ignored for `"fifo"`. Valid range:
+    /// 1-100000, default: 30. Must be set before the element starts.
+    pub fn set_queue_depth(&self, depth: u32) {
+        self.set_property("queue-depth", depth);
+    }
+
     /// Sets a shared Zenoh session for this element.
     ///
     /// This allows multiple elements to share a single Zenoh session,
@@ -244,6 +261,16 @@ impl ZenohSrc {
         self.property("apply-buffer-meta")
     }
 
+    /// Returns the receive-handler strategy (`"fifo"` or `"ring"`).
+    pub fn handler(&self) -> String {
+        self.property("handler")
+    }
+
+    /// Returns the ring-handler depth.
+    pub fn queue_depth(&self) -> u32 {
+        self.property("queue-depth")
+    }
+
     /// Returns the session group name, if set.
     pub fn session_group(&self) -> Option<String> {
         self.property("session-group")
@@ -266,6 +293,11 @@ impl ZenohSrc {
     /// Returns the total number of errors encountered.
     pub fn errors(&self) -> u64 {
         self.property("errors")
+    }
+
+    /// Returns the total samples dropped by the `"ring"` handler (0 for `"fifo"`).
+    pub fn dropped(&self) -> u64 {
+        self.property("dropped")
     }
 }
 
@@ -318,6 +350,8 @@ pub struct ZenohSrcBuilder {
     config: Option<String>,
     receive_timeout_ms: Option<u64>,
     apply_buffer_meta: Option<bool>,
+    handler: Option<String>,
+    queue_depth: Option<u32>,
     session: Option<zenoh::Session>,
     session_group: Option<String>,
 }
@@ -330,6 +364,8 @@ impl ZenohSrcBuilder {
             config: None,
             receive_timeout_ms: None,
             apply_buffer_meta: None,
+            handler: None,
+            queue_depth: None,
             session: None,
             session_group: None,
         }
@@ -350,6 +386,20 @@ impl ZenohSrcBuilder {
     /// Enables or disables applying buffer timing metadata.
     pub fn apply_buffer_meta(mut self, apply: bool) -> Self {
         self.apply_buffer_meta = Some(apply);
+        self
+    }
+
+    /// Sets the receive-handler strategy: `"fifo"` (lossless) or `"ring"`
+    /// (drop-oldest, bounds latency for live sources).
+    pub fn handler(mut self, handler: &str) -> Self {
+        self.handler = Some(handler.to_string());
+        self
+    }
+
+    /// Sets the ring-handler depth (max retained samples before drop-oldest).
+    /// Only affects the `"ring"` handler.
+    pub fn queue_depth(mut self, depth: u32) -> Self {
+        self.queue_depth = Some(depth);
         self
     }
 
@@ -386,6 +436,12 @@ impl ZenohSrcBuilder {
         }
         if let Some(apply) = self.apply_buffer_meta {
             builder = builder.property("apply-buffer-meta", apply);
+        }
+        if let Some(ref handler) = self.handler {
+            builder = builder.property("handler", handler);
+        }
+        if let Some(depth) = self.queue_depth {
+            builder = builder.property("queue-depth", depth);
         }
         if let Some(ref sg) = self.session_group {
             builder = builder.property("session-group", sg);

--- a/tests/data_flow_tests.rs
+++ b/tests/data_flow_tests.rs
@@ -503,3 +503,91 @@ fn test_statistics_during_data_flow() {
         num_buffers * buffer_size
     );
 }
+
+/// A stalled consumer with the `ring` handler must drop the oldest samples
+/// (bounding latency) and surface the count via the `dropped` stat — whereas the
+/// default `fifo` handler would queue them unbounded. Sender and receiver share
+/// one in-process session, so the flood is delivered synchronously and reliably
+/// overflows the depth-2 ring.
+#[test]
+#[serial]
+fn test_ring_handler_drops_oldest_under_stalled_consumer() {
+    init();
+
+    let key_expr = unique_key_expr("ring-drop");
+    let zenoh_session = zenoh::open(zenoh::Config::default())
+        .wait()
+        .expect("Failed to open Zenoh session");
+
+    // Receiver: ring handler with a tiny depth so a stalled consumer overflows it.
+    let recv_pipeline = gst::Pipeline::new();
+    let zenohsrc = gstzenoh::ZenohSrc::builder(&key_expr)
+        .session(zenoh_session.clone())
+        .receive_timeout_ms(50)
+        .handler("ring")
+        .queue_depth(2)
+        .build();
+    let fakesink = gst::ElementFactory::make("fakesink")
+        .property("sync", false)
+        .build()
+        .unwrap();
+    let src_elem: gst::Element = zenohsrc.clone().upcast();
+    recv_pipeline.add_many([&src_elem, &fakesink]).unwrap();
+    src_elem.link(&fakesink).unwrap();
+
+    // Stall the streaming thread on the first buffer so the ring fills from the
+    // (independent) Zenoh callback thread and starts dropping the oldest.
+    let release = Arc::new(AtomicBool::new(false));
+    let release_probe = release.clone();
+    let srcpad = zenohsrc.static_pad("src").unwrap();
+    srcpad.add_probe(gst::PadProbeType::BUFFER, move |_, _| {
+        while !release_probe.load(Ordering::SeqCst) {
+            thread::sleep(Duration::from_millis(20));
+        }
+        gst::PadProbeReturn::Ok
+    });
+
+    recv_pipeline.set_state(gst::State::Playing).unwrap();
+    thread::sleep(Duration::from_millis(500)); // establish subscription
+
+    // Flood many buffers as fast as possible through a shared session.
+    let send_pipeline = gst::Pipeline::new();
+    let appsrc = gst_app::AppSrc::builder()
+        .format(gst::Format::Bytes)
+        .build();
+    let zenohsink = gstzenoh::ZenohSink::builder(&key_expr)
+        .session(zenoh_session.clone())
+        .build();
+    let appsrc_elem: gst::Element = appsrc.clone().upcast();
+    let sink_elem: gst::Element = zenohsink.clone().upcast();
+    send_pipeline.add_many([&appsrc_elem, &sink_elem]).unwrap();
+    appsrc_elem.link(&sink_elem).unwrap();
+    send_pipeline.set_state(gst::State::Playing).unwrap();
+    thread::sleep(Duration::from_millis(100));
+
+    let num_buffers = 100u64;
+    for i in 0..num_buffers {
+        let mut buffer = gst::Buffer::with_size(16).unwrap();
+        {
+            let buf = buffer.get_mut().unwrap();
+            buf.set_pts(gst::ClockTime::from_mseconds(i));
+        }
+        let _ = appsrc.push_buffer(buffer);
+    }
+    let _ = appsrc.end_of_stream();
+
+    // Let the flood overflow the depth-2 ring while the consumer stalls.
+    thread::sleep(Duration::from_secs(1));
+
+    let dropped = zenohsrc.dropped();
+
+    // Release the consumer and tear everything down.
+    release.store(true, Ordering::SeqCst);
+    let _ = send_pipeline.set_state(gst::State::Null);
+    stop_pipeline_with_timeout(&recv_pipeline, Duration::from_secs(1));
+
+    assert!(
+        dropped > 0,
+        "ring handler under a stalled consumer should have dropped samples, got {dropped}"
+    );
+}

--- a/tests/plugin_tests.rs
+++ b/tests/plugin_tests.rs
@@ -119,6 +119,39 @@ fn test_zenohsrc_properties() {
 
 #[test]
 #[serial]
+fn test_zenohsrc_handler_properties() {
+    init();
+
+    let src = gst::ElementFactory::make("zenohsrc")
+        .build()
+        .expect("Failed to create zenohsrc");
+
+    // Defaults preserve the prior lossless behavior.
+    let handler: String = src.property("handler");
+    assert_eq!(handler, "fifo");
+    let queue_depth: u32 = src.property("queue-depth");
+    assert_eq!(queue_depth, 30);
+    // `dropped` is a read-only stat, zero before the element starts.
+    let dropped: u64 = src.property("dropped");
+    assert_eq!(dropped, 0);
+
+    // Opt into the drop-oldest ring handler with a custom depth.
+    src.set_property("handler", "ring");
+    let handler: String = src.property("handler");
+    assert_eq!(handler, "ring");
+
+    src.set_property("queue-depth", 5u32);
+    let queue_depth: u32 = src.property("queue-depth");
+    assert_eq!(queue_depth, 5);
+
+    // An invalid handler nick is rejected and leaves the value unchanged.
+    src.set_property("handler", "bogus");
+    let handler: String = src.property("handler");
+    assert_eq!(handler, "ring");
+}
+
+#[test]
+#[serial]
 fn test_zenohsink_invalid_properties() {
     init();
 

--- a/tests/uri_handler_tests.rs
+++ b/tests/uri_handler_tests.rs
@@ -84,6 +84,36 @@ fn test_zenohsrc_simple_uri() {
 
 #[test]
 #[serial]
+fn test_zenohsrc_uri_handler_params() {
+    init();
+
+    let src = gst::ElementFactory::make("zenohsrc")
+        .build()
+        .expect("Failed to create zenohsrc");
+
+    let uri_handler = src.dynamic_cast_ref::<gst::URIHandler>().unwrap();
+
+    // Parse the ring-handler params out of a URI.
+    uri_handler
+        .set_uri("zenoh:demo/video?handler=ring&queue-depth=5")
+        .unwrap();
+    let handler: String = src.property("handler");
+    assert_eq!(handler, "ring");
+    let queue_depth: u32 = src.property("queue-depth");
+    assert_eq!(queue_depth, 5);
+
+    // Non-default params round-trip back into the emitted URI.
+    let uri = uri_handler.uri().unwrap();
+    assert!(uri.contains("handler=ring"), "uri was: {uri}");
+    assert!(uri.contains("queue-depth=5"), "uri was: {uri}");
+
+    // An invalid handler nick in the URI is a BadUri error.
+    let err = uri_handler.set_uri("zenoh:demo/video?handler=bogus");
+    assert!(err.is_err(), "invalid handler should be rejected");
+}
+
+#[test]
+#[serial]
 fn test_uri_with_parameters() {
     init();
 


### PR DESCRIPTION
Closes #13. **Stacked on #12** (base is `deps/toolchain-modernization`) so it builds against the pinned zenoh 1.9 / Rust 1.96 toolchain — review the top commit, or merge the stack first.

## What
An opt-in bounded receive handler for `zenohsrc` so live sources stay near the live edge instead of draining a stale backlog after a stall. This is the highest-value, fully-unblocked slice split out of Epic #8 — it needs no `zenoh-ext` and is independent of the advanced-delivery work.

## Properties (new on `zenohsrc`)
- **`handler`** — `fifo` (default, lossless/unbounded; behavior unchanged) or `ring` (keep most-recent `queue-depth`, drop oldest).
- **`queue-depth`** (1-100000, default 30) — ring capacity; ignored for `fifo`.
- **`dropped`** (read-only) — samples evicted by the ring handler; 0 for `fifo`.

All three mirror into the typed builder/getters (`.handler()`, `.queue_depth()`, `.dropped()`) and round-trip through the URI handler (`zenoh:key?handler=ring&queue-depth=5`). `handler`/`queue-depth` are locked while the element is started.

## Why a custom handler
Zenoh's built-in `RingChannel` already drops the oldest sample — but **silently**: its callback discards the evicted element, and `RingChannelHandler` exposes no counter, so it can't back a `dropped` stat. This PR adds a small drop-counting ring handler over Zenoh's public `IntoHandler`/`Callback` API that counts each eviction into a shared atomic. The keep-latest-N logic is factored into a generic `CountingRing<T>` so it's unit-tested directly (the handler is `Sample`-typed and `Sample` has no public constructor). FIFO and ring subscribers are unified behind a `SubscriberHandle` enum, keeping the `create()` receive loop handler-agnostic.

## Tests
- Unit: drop-oldest + eviction counting, under-capacity never drops, `HandlerMode` nick parsing.
- Property: defaults (`fifo`/30/0), set/get, invalid nick rejected.
- URI: `handler`/`queue-depth` parse + round-trip + invalid-nick error.
- E2E (deterministic): a stalled consumer with a depth-2 ring drops the oldest under a 100-buffer flood over a shared in-process session; `dropped > 0`. Ran 3× with no flakiness.

## Verification (Rust 1.96.0)
- `cargo +1.96.0 fmt --check` ✅
- `cargo +1.96.0 clippy --all-targets -- -D warnings` ✅
- `cargo +1.96.0 test` ✅ — full suite green (25 lib unit tests incl. the new 3; all integration suites pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
